### PR TITLE
#167231966 Change User Registration page to Modal Dialog

### DIFF
--- a/src/accounts/forms.py
+++ b/src/accounts/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib.auth.forms import ReadOnlyPasswordHashField
+from bootstrap_modal_forms.mixins import PopRequestMixin, CreateUpdateAjaxMixin
 from .models import User
 
 class UserCreationForm(forms.ModelForm):
@@ -8,7 +9,7 @@ class UserCreationForm(forms.ModelForm):
     """
     password1 = forms.CharField(label='Password', widget=forms.PasswordInput)
     password2 = forms.CharField(label='Confirm Password', widget=forms.PasswordInput)
-    is_admin = forms.BooleanField(label='Is Admin', widget=forms.CheckboxInput)
+    is_admin = forms.BooleanField(label='Is Admin', required=False, widget=forms.CheckboxInput)
 
     class Meta:
         model = User
@@ -52,7 +53,7 @@ class UserChangeForm(forms.ModelForm):
     def clean_password(self):
         return self.initial['password']
 
-class UserRegisterForm(UserCreationForm):
+class UserRegisterForm(PopRequestMixin, CreateUpdateAjaxMixin, UserCreationForm):
     email = forms.EmailField()
     
     class Meta:

--- a/src/accounts/static/accounts/css/style.css
+++ b/src/accounts/static/accounts/css/style.css
@@ -38,4 +38,3 @@
     .sidenav {padding-top: 15px;}
     .sidenav a {font-size: 18px;}
   }
-

--- a/src/accounts/templates/accounts/base.html
+++ b/src/accounts/templates/accounts/base.html
@@ -9,6 +9,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
   {% load static %}
+  <script src="{% static 'js/jquery.bootstrap.modal.forms.min.js' %}"></script>
   <link rel="stylesheet" type="text/css" href="{% static 'accounts/css/style.css' %}">
   <script type="text/javascript" src="{% static 'accounts/js/script.js' %}"></script>
   <title>Super Record - {% block title %}{%endblock%}</title>

--- a/src/accounts/templates/accounts/signup.html
+++ b/src/accounts/templates/accounts/signup.html
@@ -1,21 +1,35 @@
-{% extends "accounts/nav.html" %}
-
-{% load crispy_forms_tags %}
-{% block title%}Signup{%endblock%}
+{% load widget_tweaks %}
 
 {% block content%}
-  <div class="container mt-5 border" style="width: 40%">
-    <form action="." method="POST">
-        {% csrf_token %}
-        <div class="form-group">
-            <legend class="border-bottom my-4">Register</legend>
-            {{ form|crispy }}
+    <form method="post">
+    {% csrf_token %}
+        <div class="modal-header">
+            <h5 class="modal-title text-primary">ADD STAFF MEMBER</h5>
         </div>
-        <button class="btn btn-primary" type="submit">Sign Up</button>
+
+        <div class="modal-body my-0">
+            <div class="{% if form.non_field_errors %}invalid{% endif %} mb-2">
+                {% for error in form.non_field_errors %}
+                    {{ error }}
+                {% endfor %}
+            </div>
+
+            {% for field in form %}
+                <div class="form-group">
+                    <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+                    {% render_field field class="form-control" placeholder=field.label %}
+                    <div class="{% if field.errors %} invalid{% endif %}">
+                        {% for error in field.errors %}
+                            <p class="help-block">{{ error }}</p>
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+
+        <div class="modal-footer form-group justify-content-start">
+            <button type="submit" class="btn-primary py-1">ADD STAFF MEMBER</button>
+            <button type="reset" class="border border-primary text-primary px-3 py-1" data-dismiss="modal">CANCEL</button>
+        </div>
     </form>
-    <div class="my-2">
-        <p>Have an account already? <a href="{% url 'login' %}">Login here</a></p>
-    </div>
-    
-</div>
 {%endblock%}

--- a/src/accounts/templates/accounts/user.html
+++ b/src/accounts/templates/accounts/user.html
@@ -1,22 +1,82 @@
-<div class="container my-2" style="font-size: 28px; ">
-    <h1>User List</h1>
-    <p>Registered System Users</p>
-    <p class="font-weight-light"> 
-        Some text to enable scrolling.. Lorem ipsum dolor sit amet, 
-        illum definitiones no quo, maluisset concludaturque et eum, altera fabulas ut quo. 
-        Atqui causae gloriatur ius te, id agam omnis evertitur eum. Affert laboramus repudiandae nec et. 
-        Inciderint efficiantur his ad. Eum no molestiae voluptatibus.
-    </p>
-    <p class="font-weight-light"> 
-        Some text to enable scrolling.. Lorem ipsum dolor sit amet, 
-        illum definitiones no quo, maluisset concludaturque et eum, altera fabulas ut quo. 
-        Atqui causae gloriatur ius te, id agam omnis evertitur eum. Affert laboramus repudiandae nec et. 
-        Inciderint efficiantur his ad. Eum no molestiae voluptatibus.
-    </p>
-    <p class="font-weight-light"> 
-        Some text to enable scrolling.. Lorem ipsum dolor sit amet, 
-        illum definitiones no quo, maluisset concludaturque et eum, altera fabulas ut quo. 
-        Atqui causae gloriatur ius te, id agam omnis evertitur eum. Affert laboramus repudiandae nec et. 
-        Inciderint efficiantur his ad. Eum no molestiae voluptatibus.
-    </p>
+{% block extra_js%}
+    <script src="http://malsup.github.com/jquery.form.js"></script>
+{% endblock %}
+
+{% load crispy_forms_tags %}
+
+<div class="container my-2">
+    <div class="navbar navbar-light mb-3 text-monospace ">
+        <h4 class="text-uppercase font-weight-lighter">User</h4>
+        <a class="signup-btn nav-link border border-primary px-3 py-2 text-primary"
+            data-toggle="modal"
+            data-target="#exampleModal"
+            href="{% url 'signup' %}"
+            title="Add Staff Member"
+            data-tooltip>Add User</a>
+    </div>
+    <!-- Modal -->
+    <div class="modal fade" tabindex="-1" role="dialog" id="modal">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content"></div>
+        </div>
+    </div>
+    
+    <script type="text/javascript">
+        $(function () {
+            // Sign up button
+            $(".signup-btn").modalForm({formURL: "{% url 'signup' %}"});
+        });
+    </script>
+    
+    <!-- End of modal -->
+    <div>
+        <p class="font-weight-light"> 
+            Some text to enable scrolling.. Lorem ipsum dolor sit amet, 
+            illum definitiones no quo, maluisset concludaturque et eum, altera fabulas ut quo. 
+            Atqui causae gloriatur ius te, id agam omnis evertitur eum. Affert laboramus repudiandae nec et. 
+            Inciderint efficiantur his ad. Eum no molestiae voluptatibus.
+        </p>
+        <p class="font-weight-light"> 
+            Some text to enable scrolling.. Lorem ipsum dolor sit amet, 
+            illum definitiones no quo, maluisset concludaturque et eum, altera fabulas ut quo. 
+            Atqui causae gloriatur ius te, id agam omnis evertitur eum. Affert laboramus repudiandae nec et. 
+            Inciderint efficiantur his ad. Eum no molestiae voluptatibus.
+        </p>
+        <p class="font-weight-light"> 
+            Some text to enable scrolling.. Lorem ipsum dolor sit amet, 
+            illum definitiones no quo, maluisset concludaturque et eum, altera fabulas ut quo. 
+            Atqui causae gloriatur ius te, id agam omnis evertitur eum. Affert laboramus repudiandae nec et. 
+            Inciderint efficiantur his ad. Eum no molestiae voluptatibus.
+        </p>
+        <p class="font-weight-light"> 
+            Some text to enable scrolling.. Lorem ipsum dolor sit amet, 
+            illum definitiones no quo, maluisset concludaturque et eum, altera fabulas ut quo. 
+            Atqui causae gloriatur ius te, id agam omnis evertitur eum. Affert laboramus repudiandae nec et. 
+            Inciderint efficiantur his ad. Eum no molestiae voluptatibus.
+        </p>
+        <p class="font-weight-light"> 
+            Some text to enable scrolling.. Lorem ipsum dolor sit amet, 
+            illum definitiones no quo, maluisset concludaturque et eum, altera fabulas ut quo. 
+            Atqui causae gloriatur ius te, id agam omnis evertitur eum. Affert laboramus repudiandae nec et. 
+            Inciderint efficiantur his ad. Eum no molestiae voluptatibus.
+        </p>
+        <p class="font-weight-light"> 
+            Some text to enable scrolling.. Lorem ipsum dolor sit amet, 
+            illum definitiones no quo, maluisset concludaturque et eum, altera fabulas ut quo. 
+            Atqui causae gloriatur ius te, id agam omnis evertitur eum. Affert laboramus repudiandae nec et. 
+            Inciderint efficiantur his ad. Eum no molestiae voluptatibus.
+        </p>
+        <p class="font-weight-light"> 
+            Some text to enable scrolling.. Lorem ipsum dolor sit amet, 
+            illum definitiones no quo, maluisset concludaturque et eum, altera fabulas ut quo. 
+            Atqui causae gloriatur ius te, id agam omnis evertitur eum. Affert laboramus repudiandae nec et. 
+            Inciderint efficiantur his ad. Eum no molestiae voluptatibus.
+        </p>
+        <p class="font-weight-light"> 
+            Some text to enable scrolling.. Lorem ipsum dolor sit amet, 
+            illum definitiones no quo, maluisset concludaturque et eum, altera fabulas ut quo. 
+            Atqui causae gloriatur ius te, id agam omnis evertitur eum. Affert laboramus repudiandae nec et. 
+            Inciderint efficiantur his ad. Eum no molestiae voluptatibus.
+        </p>
+    </div>
 </div>

--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -1,20 +1,17 @@
 from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
+from django.utils.decorators import method_decorator
+from django.urls import reverse_lazy
+from django.views import View
+from bootstrap_modal_forms.generic import BSModalCreateView
 from .forms import UserRegisterForm
 
-@login_required
-def register(request):
-    if request.method == 'POST':
-        form = UserRegisterForm(request.POST)
-        if form.is_valid():
-            form.save()
-            return redirect('login')
-    else:
-        form = UserRegisterForm()
-    context = {
-        'form': form,
-    }
-    return render(request, 'accounts/signup.html', context)
+@method_decorator(login_required, name='dispatch')
+class SignUpView(BSModalCreateView):
+    form_class = UserRegisterForm
+    template_name = 'accounts/signup.html'
+    success_message = 'Success: Sign up succeeded. You can now Log in.'
+    success_url = reverse_lazy('setting')
 
 @login_required
 def home(request):

--- a/src/superrecord/settings.py
+++ b/src/superrecord/settings.py
@@ -38,7 +38,9 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'accounts.apps.AccountsConfig',
-    'crispy_forms'
+    'crispy_forms',
+    'bootstrap_modal_forms',
+    'widget_tweaks',
 ]
 
 MIDDLEWARE = [

--- a/src/superrecord/urls.py
+++ b/src/superrecord/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     path('', index, name='index'),
     path('accounts/user/', user_views.user, name='user'),
     path('accounts/home/', user_views.home, name='home'),
-    path('accounts/signup/', user_views.register, name='signup'),
+    path('accounts/signup/', user_views.SignUpView.as_view(), name='signup'),
     path('accounts/login/', auth_views.LoginView.as_view(template_name='accounts/login.html'), name='login'),
     path('accounts/logout/', auth_views.LogoutView.as_view(template_name='accounts/logout.html'), name='logout'),
     path('accounts/product/', user_views.product, name='product'),


### PR DESCRIPTION
#### What does this PR do?
This PR Change the user registration page to modal dialog.

#### Description of Task to be completed?
- Add a user registration model for registering new users

#### How should this be manually tested?
- Clone this branch
- In the root directory run `python manage.py runserver`
- Navigate to `http://127.0.0.1:8000/` to login
- Navigate to `http://127.0.0.1:8000/accounts/settings` 
- Select `Users` menu on the left
- Click on the `Add User` button
#### Any background context you want to provide?
Currently there is a page for registering users. This should be converted into a model accessible through a button at the top of the user report page and should popup when the button is clicked.

#### What are the relevant pivotal tracker stories?
[#167231966](https://www.pivotaltracker.com/story/show/167231966)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/29800415/61142570-c1a1ac00-a4d8-11e9-9431-443298b2ffa5.png)
<br />
![image](https://user-images.githubusercontent.com/29800415/61142581-c6fef680-a4d8-11e9-9dee-cf828219afa5.png)


#### Questions:
N/A