### PR TITLE
#168168753 Add Views for the Purchase App

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,3 +97,4 @@ workflows:
               only:
                 - master
                 - develop
+                - ft-add-purchase-views-168168753

--- a/src/accounts/forms.py
+++ b/src/accounts/forms.py
@@ -1,11 +1,6 @@
 from django import forms
-from django.contrib.auth.forms import (
-    ReadOnlyPasswordHashField,
-    PasswordChangeForm
-)
-
+from django.contrib.auth.forms import ReadOnlyPasswordHashField
 from .models import User, Role
-from .permissions import assign_permissions
 
 class UserCreationForm(forms.ModelForm):
     """
@@ -49,7 +44,7 @@ class UserCreationForm(forms.ModelForm):
 
 class UserChangeForm(forms.ModelForm):
     """
-    A form for updating users with all fields while replacing password 
+    A form for updating users with all fields while replacing password
     field with admin's password hash display field
     """
     password = ReadOnlyPasswordHashField()
@@ -63,13 +58,13 @@ class UserChangeForm(forms.ModelForm):
 
 class UserRegisterForm(UserCreationForm):
     email = forms.EmailField()
-    
+
     class Meta:
         model = User
         fields = ['username', 'email', 'password1', 'password2']
 
 class EditProfileForm(UserChangeForm):
-    
+
     class Meta:
         model = User
         fields = ['username', 'email', 'password']
@@ -81,7 +76,7 @@ class RoleCreationForm(forms.ModelForm):
         fields = ('name', 'description')
 
 class EditRoleForm(forms.ModelForm):
-    
+
     class Meta:
         model = Role
         fields = ['name', 'description']

--- a/src/accounts/models.py
+++ b/src/accounts/models.py
@@ -57,8 +57,8 @@ class UserManager(BaseUserManager):
 
 class User(AbstractBaseUser, PermissionsMixin):
     """
-    Class for creating user implementing the abstract 
-    base user and the permission class 
+    Class for creating user implementing the abstract
+    base user and the permission class
     """
     username = models.CharField(max_length=255, unique=True)
     email = models.EmailField(verbose_name='email address', max_length=255,unique=True)
@@ -69,14 +69,14 @@ class User(AbstractBaseUser, PermissionsMixin):
 
     USERNAME_FIELD = 'username'
     REQUIRED_FIELDS = ['email']
-    
+
     objects = UserManager()
 
     def __str__(self):
         """Returns a string representation of this `User`."""
         return self.username
 
-    def delete(self):
+    def delete(self, using=None, keep_parents=False):
         self.is_active ^= True
         self.save()
 

--- a/src/accounts/permissions.py
+++ b/src/accounts/permissions.py
@@ -1,8 +1,7 @@
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from .models import User
 
-def assign_permissions(role, perm_list=[], full=False):
+def assign_permissions(role, perm_list, full=False):
     all_perms = []
 
     if not role and not perm_list:

--- a/src/accounts/templates/accounts/setting.html
+++ b/src/accounts/templates/accounts/setting.html
@@ -14,7 +14,7 @@
                 if ($(this).attr("id") == 'products'){
                     pageurl = page.replace("user",$(this).attr("id"));
                     pageurl = pageurl.replace("accounts", "stocks");
-                } else if ($(this).attr("id") == 'purchase'){
+                } else if ($(this).attr("id") == 'purchases'){
                     pageurl = page.replace("user",$(this).attr("id"));
                     pageurl = pageurl.replace("accounts", "purchases");
                 }else{  
@@ -29,9 +29,9 @@
             <a id =user class="selected" href="#users"><i class="fa fa-users mr-1"></i>Users</a>
             <a id ="roles" href="#roles">Roles</a> 
             <a id="products" href="#products">Stocks</a>
-            <a id="purchase" href="#purchases">Purchase</a>
+            <a id="purchases" href="#purchases">Purchases</a>
             <a id="sales" href="#sales">Sales</a>
-            <a id="expense" href="#expense"><i class="fa fa-money mr-1"></i>Expense</a>
+            <a id="expense" href="#expense"><i class="fa fa-money mr-1"></i>Expenses</a>
         </div>
         <div class="embed-responsive main" style="max-width: 92%;">
             <div id='view'></div>

--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -1,12 +1,10 @@
-from django.shortcuts import render
 from django.http import HttpResponseRedirect
 from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
 from django.urls import reverse_lazy
 from django.views.generic import (
     ListView, UpdateView, DetailView, DeleteView, CreateView, TemplateView )
-from bootstrap_modal_forms.generic import BSModalCreateView
-from .forms import ( UserRegisterForm, EditProfileForm, 
+from .forms import ( UserRegisterForm, EditProfileForm,
     RoleCreationForm, EditRoleForm )
 from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth.views import PasswordChangeView
@@ -146,20 +144,19 @@ class EditRoleView(UpdateView, DetailView):
     old_perms = []
 
     def get(self, request, *args, **kwargs):
-        self.id = kwargs['id']
-        self.edit_role = Role.objects.get(id=self.id)
+        self.edit_role = Role.objects.get(id=kwargs['id'])
 
         return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['role_perms'] = self.edit_role.permissions.all().values_list('codename', flat=True)
-    
+
         return context
-      
+
     def post(self, request, *args, **kwargs):
-        id = kwargs['id']
-        edit_role = Role.objects.get(id=id)
+
+        edit_role = Role.objects.get(id=kwargs['id'])
         self.old_perms += edit_role.permissions.all().values_list('codename', flat=True)
         new_perm = request.POST.getlist('user_perm')
 

--- a/src/decorators/decorators.py
+++ b/src/decorators/decorators.py
@@ -6,8 +6,8 @@ def group_required(group_names):
     def in_groups(u):
         group = []
         if u.is_authenticated:
-            group += u.groups.all().values_list('name', flat=True) 
-            
+            group += u.groups.all().values_list('name', flat=True)
+
             if len(group) > 0 and group[0] in group_names or u.is_superuser:
                 return user_passes_test(in_groups)
         else:

--- a/src/purchase/admin.py
+++ b/src/purchase/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/src/purchase/forms.py
+++ b/src/purchase/forms.py
@@ -1,0 +1,21 @@
+from django import forms
+from .models import Purchase
+
+class PurchaseCreationForm(forms.ModelForm):
+    """
+    A form for adding new purchase with all required field
+    """
+    class Meta:
+        model = Purchase
+        fields = ('name', 'description', 'quantity', 'cost_price', 'current_stock_level',
+                'total_stock_level', 'supplier_tel', 'created_by')
+
+class EditPurchaseForm(forms.ModelForm):
+    """
+    A form for editing existing purchase with all required field
+    """
+    class Meta:
+        model = Purchase
+        fields = ['name', 'description', 'quantity', 'cost_price','current_stock_level',
+                'total_stock_level', 'supplier_tel',]
+        exclude = ['created_by']

--- a/src/purchase/templates/purchase/add_purchase.html
+++ b/src/purchase/templates/purchase/add_purchase.html
@@ -1,0 +1,37 @@
+{% load widget_tweaks %}
+
+{% block content%}
+    <form method="post" action="{% url 'purchase' %}">
+    {% csrf_token %}
+        <div class="modal-header my-0">
+            <h5 class="modal-title text-primary">ADD NEW PURCHASE</h5>
+        </div>
+
+        <div class="modal-body my-0">
+            <div class="{% if form.non_field_errors %}invalid{% endif %} mb-2">
+                {% for error in form.non_field_errors %}
+                    {{ error }}
+                {% endfor %}
+            </div>
+
+            {% for field in form %}
+                <div class="form-group">
+                    {% if field.name not in 'total_stock_level,created_by' %}
+                        <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+                        {% render_field field class="form-control" placeholder=field.label %}
+                        <div class="{% if field.errors %} invalid{% endif %}">
+                            {% for error in field.errors %}
+                                <p class="help-block">{{ error }}</p>
+                            {% endfor %}
+                        </div>
+                    {% endif %}
+                </div>
+            {% endfor %}
+        </div>
+
+        <div class="modal-footer form-group justify-content-start">
+            <button type="submit" class="btn-primary py-1">ADD NEW PURCHASE</button>
+            <a href="#close" type="reset" class="btn border border-primary text-primary px-3 py-1" rel="modal:close">CANCEL</a>
+        </div>
+    </form>
+{%endblock%}

--- a/src/purchase/templates/purchase/delete_purchase.html
+++ b/src/purchase/templates/purchase/delete_purchase.html
@@ -1,0 +1,23 @@
+{% load widget_tweaks %}
+
+{% block content%}
+    <form method="post" action="{% url 'delete_purchase' object.id %}">
+    {% csrf_token %}
+        <div class="modal-header">
+            <h5 class="modal-title text-primary">DELETE PURCHASE COMFIRMATION</h5>
+        </div>
+
+        <div class="modal-body my-0">
+            <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+            Do you really want to delete purchase "{{ object }}"?
+        </div>
+
+        <div class="modal-footer form-group justify-content-start">
+            <button class="btn-danger py-1" type="submit">YES, DELETE</button>
+            <a class="btn border border-primary text-primary px-3 py-1"
+                href="#close"
+                type="reset"
+                rel="modal:close">CANCEL</a>
+        </div>
+    </form>
+{%endblock%}

--- a/src/purchase/templates/purchase/edit_purchase.html
+++ b/src/purchase/templates/purchase/edit_purchase.html
@@ -1,0 +1,35 @@
+{% load widget_tweaks %}
+
+{% block content%}
+    <form method="post" action="{% url 'edit_purchase' purchase.id %}">
+    {% csrf_token %}
+        <div class="modal-header my-0">
+            <h5 class="modal-title text-primary">EDIT PURCHASE</h5>
+        </div>
+
+        <div class="modal-body my-0">
+            <div class="{% if form.non_field_errors %}invalid{% endif %} mb-2">
+                {% for error in form.non_field_errors %}
+                    {{ error }}
+                {% endfor %}
+            </div>
+
+            {% for field in form %}
+                <div class="form-group">
+                    <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+                    {% render_field field class="form-control" placeholder=field.label %}
+                    <div class="{% if field.errors %} invalid{% endif %}">
+                        {% for error in field.errors %}
+                            <p class="help-block">{{ error }}</p>
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+
+        <div class="modal-footer form-group justify-content-start">
+            <button type="submit" class="btn-primary py-1">UPDATE PURCHASE</button>
+            <a href="#close" type="reset" class="btn border border-primary text-primary px-3 py-1" rel="modal:close">CANCEL</a>
+        </div>
+    </form>
+{%endblock%}

--- a/src/purchase/templates/purchase/purchase.html
+++ b/src/purchase/templates/purchase/purchase.html
@@ -1,3 +1,98 @@
-<div class="container mt-5">
-    <h1>This is the purchase page</h1>
+{% load static %}
+<div class="container my-2">
+    <div class="row navbar navbar-light mb-3 text-monospace ">
+        <h5 class="text-uppercase font-weight-lighter">Purchase List</h5>
+        <a class="nav-link border border-primary px-3 py-2 text-primary"
+            href="{% url 'purchase' %}"
+            title="Add New Purchase"
+            rel="modal:open"><i class="fa fa-plus mr-1"></i>New Purchase</a>
+    </div>
+    <!-- Modal -->
+    <div class="modal fade" tabindex="-1" role="dialog" id="modal" style="z-index: 50px">
+        <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content"></div>
+        </div>
+    </div>
+
+    <script type="text/javascript">
+        $(document).ready(function() {
+            $("#index #page a").click(function() {
+                page = $(this).attr("href");
+                pageurl = page.replace("#",'');
+                $("#view").load(pageurl);
+            });
+        });
+    </script>
+
+    <style type="text/css">
+        .parent .row:hover {
+            background-color: gray;
+            box-shadow: 0 1rem 1.5rem rgba(0,0,0,.07)!important;
+          }
+    </style>
+    <!-- End of modal -->
+    <!-- content -->
+    <div class="text-monospace">
+        {% if not purchase_list %}        
+            <div class="d-flex justify-content-center">
+                <p>No purchase available yet! Please use the New Purchase button to add some. </p>
+            </div>
+        {% else %}
+            <div class="row text-muted border-bottom mb-2">
+                <div class="col-2 pl-3">Name</div>
+                <div class="col-3 px-0">Description</div>
+                <div class="col-1 pl-2">Quantity</div>
+                <div class="col-1 px-0">Cost Price</div>
+                <div class="col-1 px-0">Current Stock Level</div>
+                <div class="col-1 px-0">Total Stock Level</div>
+                <div class="col-2 px-0">Supplier Phone</div>
+                <div class="col-1 pl-4">Action</div>
+            </div>
+            {% for purchase in purchase_list %}
+                <div class="parent">
+                    <div class="row highlight bg-light mb-2 py-2">
+                        <div class="col-2 pl-3">{{ purchase.name }}</div>
+                        <div class="col-3 px-0">{{ purchase.description }}</div>
+                        <div class="col-1 pl-2">{{ purchase.quantity }}</div>
+                        <div class="col-1 px-0">{{ purchase.cost_price }}</div>
+                        <div class="col-1 px-0">{{ purchase.current_stock_level }}</div>
+                        <div class="col-1 px-0">{{ purchase.total_stock_level }}</div>
+                        <div class="col-2 px-0">{{ purchase.supplier_tel }}</div>
+                        <div class="col-1 px-0">
+                            <a class="btn btn-sm"
+                                title="Edit Purchase"
+                                href="{% url 'edit_purchase' purchase.id %}"
+                                rel="modal:open"><i class="fa fa-edit mr-1"></i>Edit</a>
+                            <a class="btn btn-sm text-danger"
+                                title="Delete Purchase"
+                                href="{% url 'delete_purchase' purchase.id %}"
+                                rel="modal:open"><i class="fa fa-trash mr-1"></i>Delete</a></div>
+                    </div>
+                </div>
+            {% endfor %}
+
+            <div id="page" class="pagination justify-content-end mt-4"> 
+                <span class="step-links">
+                    <span>
+                        {% if page_obj.has_previous %}
+                            <a class="btn" href="#{% url 'purchases' %}?page={{ page_obj.previous_page_number }}">PREVIOUS</a>
+                        {% else %}
+                            <a href="#" class="btn disabled text-muted">PREVIOUS</a>
+                        {% endif %}
+                    </span>
+                    <span>
+                        Page {{ page_obj.number }} of {{ paginator.num_pages }}
+                    </span>
+                    <span>
+                        {% if page_obj.has_next %}
+                            <a class="btn" href="#{% url 'purchases' %}?page={{ page_obj.next_page_number }}">NEXT</a>
+                        {% else %}
+                            <a href="#" class="btn disabled text-muted">NEXT</a>
+                        {% endif %}
+                    </span>
+                </span>
+            </div>
+        {% endif %}
+    </div>
+    <!-- End of content -->
 </div>

--- a/src/purchase/tests/test_forms.py
+++ b/src/purchase/tests/test_forms.py
@@ -1,0 +1,105 @@
+from django.test import TestCase
+from accounts.models import User
+from ..forms import PurchaseCreationForm, EditPurchaseForm
+
+class PurchaseCreationFormTest(TestCase):
+    def setUp(self):
+        self.test = User.objects.create_user("test", "test@info.com", "1234@test")
+        self.purch_creater = PurchaseCreationForm()
+        self.purch_creater2 = PurchaseCreationForm(
+            data={
+                'name': 'sugar',
+                'description': 'This is a stock of kakira sugar',
+                'quantity': 10,
+                'cost_price': 3000.0,
+                'current_stock_level': 10,
+                'total_stock_level': 20,
+                'supplier_tel': '256710000000',
+                'created_by': self.test.id
+            }
+        )
+
+    def test_purchase_name_field_label(self):
+        self.assertFalse(self.purch_creater.fields['name'].label == None)
+        self.assertFalse(self.purch_creater.fields['name'].label == 'name')
+
+    def test_purchase_description_field_label(self):
+        self.assertFalse(self.purch_creater.fields['description'].label == None)
+        self.assertFalse(self.purch_creater.fields['description'].label == 'description')
+
+    def test_purchase_quantity_field_label(self):
+        self.assertFalse(self.purch_creater.fields['quantity'].label == None)
+        self.assertFalse(self.purch_creater.fields['quantity'].label == 'quantity')
+
+    def test_purchase_cost_price_field_label(self):
+        self.assertFalse(self.purch_creater.fields['cost_price'].label == None)
+        self.assertFalse(self.purch_creater.fields['cost_price'].label == 'cost_price')
+
+    def test_purchase_current_stock_level_field_label(self):
+        self.assertFalse(self.purch_creater.fields['current_stock_level'].label == None)
+        self.assertFalse(self.purch_creater.fields['current_stock_level'].label == 'current_stock_level')
+
+    def test_purchase_total_stock_level_field_label(self):
+        self.assertFalse(self.purch_creater.fields['total_stock_level'].label == None)
+        self.assertFalse(self.purch_creater.fields['total_stock_level'].label == 'total_stock_level')
+
+    def test_purchase_supplier_tel_field_label(self):
+        self.assertFalse(self.purch_creater.fields['supplier_tel'].label == None)
+        self.assertFalse(self.purch_creater.fields['supplier_tel'].label == 'supplier_tel')
+
+    def test_form_is_valid(self):
+        self.assertTrue(self.purch_creater2.is_valid())
+
+    def test_form_is_not_valid(self):
+        self.assertFalse(self.purch_creater.is_valid())
+
+class EditPurchaseFormTest(TestCase):
+    def setUp(self):
+        self.test = User.objects.create_user("test", "test@info.com", "1234@test")
+        self.purch_creater = EditPurchaseForm()
+        self.purch_creater2 = EditPurchaseForm(
+            data={
+                'name': 'sugar',
+                'description': 'This is a stock of kakira sugar',
+                'quantity': 10,
+                'cost_price': 4000.0,
+                'current_stock_level': 10,
+                'total_stock_level': 20,
+                'supplier_tel': '256710000001',
+                'created_by': self.test.id
+            }
+        )
+
+    def test_purchase_name_field_label(self):
+        self.assertFalse(self.purch_creater.fields['name'].label == None)
+        self.assertFalse(self.purch_creater.fields['name'].label == 'name')
+
+    def test_purchase_description_field_label(self):
+        self.assertFalse(self.purch_creater.fields['description'].label == None)
+        self.assertFalse(self.purch_creater.fields['description'].label == 'description')
+
+    def test_purchase_quantity_field_label(self):
+        self.assertFalse(self.purch_creater.fields['quantity'].label == None)
+        self.assertFalse(self.purch_creater.fields['quantity'].label == 'quantity')
+
+    def test_purchase_cost_price_field_label(self):
+        self.assertFalse(self.purch_creater.fields['cost_price'].label == None)
+        self.assertFalse(self.purch_creater.fields['cost_price'].label == 'cost_price')
+
+    def test_purchase_current_stock_level_field_label(self):
+        self.assertFalse(self.purch_creater.fields['current_stock_level'].label == None)
+        self.assertFalse(self.purch_creater.fields['current_stock_level'].label == 'current_stock_level')
+
+    def test_purchase_total_stock_level_field_label(self):
+        self.assertFalse(self.purch_creater.fields['total_stock_level'].label == None)
+        self.assertFalse(self.purch_creater.fields['total_stock_level'].label == 'total_stock_level')
+
+    def test_purchase_supplier_tel_field_label(self):
+        self.assertFalse(self.purch_creater.fields['supplier_tel'].label == None)
+        self.assertFalse(self.purch_creater.fields['supplier_tel'].label == 'supplier_tel')
+
+    def test_form_is_valid(self):
+        self.assertTrue(self.purch_creater2.is_valid())
+
+    def test_form_is_not_valid(self):
+        self.assertFalse(self.purch_creater.is_valid())

--- a/src/purchase/tests/test_views.py
+++ b/src/purchase/tests/test_views.py
@@ -1,0 +1,130 @@
+from django.test import TestCase
+from django.urls import reverse_lazy
+from django.contrib.auth.models import Group
+from accounts.models import User, Role
+from ..models import Purchase
+
+class PurchaseCreationViewTest(TestCase):
+    def setUp(self):
+        self.test = User.objects.create_user("test", "test@info.com", "1234@test")
+        self.role = Role.objects.create(name="Manager", description="This is a manager role")
+        self.test.save()
+        self.role.save()
+        self.data = {
+            'name': 'sugar',
+            'description': 'This is a stock of kakira sugar',
+            'quantity': 10,
+            'cost_price': 3000.0,
+            'current_stock_level': 10,
+            'total_stock_level': 20,
+            'supplier_tel': '256710000000',
+            'created_by': self.test.id
+        }
+        self.username = 'test'
+        self.password = '1234@test'
+
+    def test_purchase_list_can_be_accessed(self):
+        self.test.groups.add(Group.objects.get(name='Manager'))
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.get(reverse_lazy('purchases'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'purchase/purchase.html')
+
+    def test_purchase_creation(self):
+        self.test.groups.add(Group.objects.get(name='Manager'))
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.post(reverse_lazy('purchase'), data=self.data)
+        self.assertEqual(response.status_code, 302)
+
+    def test_purchase_count(self):
+        self.test.groups.add(Group.objects.get(name='Manager'))
+        self.client.login(username=self.username, password=self.password)
+        self.client.post(reverse_lazy('purchase'), data=self.data)
+        count = Purchase.objects.count()
+        self.assertEqual(count, 1)
+
+    def test_purchase_creation_with_no_login(self):
+        self.test.groups.add(Group.objects.get(name='Manager'))
+        response = self.client.post(reverse_lazy('purchase'), data=self.data)
+        self.assertEqual(response.status_code, 302)
+
+    def test_purchase_creation_by_get(self):
+        self.test.groups.add(Group.objects.get(name='Manager'))
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.post(reverse_lazy('purchase'))
+        self.assertEqual(response.status_code, 200)
+
+class PurchaseEditViewTest(TestCase):
+    def setUp(self):
+        test = User.objects.create_user("test", "test@info.com", "1234@test")
+        self.role = Role.objects.create(name="Manager", description="This is a manager role")
+        test.save()
+        self.role.save()
+        test.groups.add(Group.objects.get(name='Manager'))
+        self.purch = Purchase.objects.create(name="bread", description="This is a stock of bread",
+                                quantity=20, cost_price=5000.0, current_stock_level=20,
+                                total_stock_level=40,
+                                supplier_tel='256710000000',
+                                created_by=User.objects.get(username="test"))
+        self.data = {
+            'name': 'sugar',
+            'description': 'This is a stock of sugar',
+            'quantity': 20,
+            'cost_price': 4000.0,
+            'current_stock_level': 20,
+            'total_stock_level': 40,
+            'supplier_tel': '256710000001'
+        }
+        self.username = 'test'
+        self.password = '1234@test'
+
+    def test_edit_purchase_can_be_accessed(self):
+        self.client.login(username=self.username, password=self.password)
+        resp = self.client.get(reverse_lazy('edit_purchase', kwargs={'id':self.purch.id}))
+        self.assertEqual(resp.status_code, 200)
+        self.assertTemplateUsed(resp, 'purchase/edit_purchase.html')
+
+    def test_edit_purchase(self):
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.post(reverse_lazy('edit_purchase', kwargs={'id':self.purch.id}), data=self.data)
+        self.assertEqual(response.status_code, 302)
+
+    def test_edit_purchase_by_get(self):
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.post(reverse_lazy('edit_purchase', kwargs={'id':self.purch.id}))
+        self.assertEqual(response.status_code, 200)
+
+class PurchaseDeleteViewTest(TestCase):
+    def setUp(self):
+        test = User.objects.create_user("test", "test@info.com", "1234@test")
+        self.role = Role.objects.create(name="Manager", description="This is a manager role")
+        test.save()
+        self.role.save()
+        test.groups.add(Group.objects.get(name='Manager'))
+        self.purch = Purchase.objects.create(name="bread", description="This is a stock of bread",
+                                quantity=20, cost_price=5000.0, current_stock_level=20,
+                                total_stock_level=40,
+                                supplier_tel='256710000000',
+                                created_by=User.objects.get(username="test"))
+        self.data = {
+            'name': 'sugar',
+            'description': 'This is a stock of sugar',
+            'quantity': 20,
+            'cost_price': 4000.0,
+            'current_stock_level': 20,
+            'total_stock_level': 40,
+            'supplier_tel': '256710000001'
+        }
+        self.username = 'test'
+        self.password = '1234@test'
+
+    def test_delete_purchase_can_be_accessed(self):
+        self.client.login(username=self.username, password=self.password)
+        resp = self.client.get(reverse_lazy('delete_purchase', kwargs={'id':self.purch.id}))
+        self.assertEqual(resp.status_code, 200)
+        self.assertTemplateUsed(resp, 'purchase/delete_purchase.html')
+
+    def test_delete_purchase(self):
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.post(reverse_lazy('delete_purchase', kwargs={'id':self.purch.id}))
+        self.assertEqual(response.status_code, 302)

--- a/src/purchase/urls.py
+++ b/src/purchase/urls.py
@@ -2,5 +2,8 @@ from django.urls import path
 from purchase import views as purchase_views
 
 urlpatterns = [
-    path('purchase/', purchase_views.Purchase.as_view(), name='purchase'),
+    path('purchases/', purchase_views.PurchaseListView.as_view(), name='purchases'),
+    path('purchase/', purchase_views.PurchaseCreationView.as_view(), name='purchase'),
+    path('edit_purchase/<int:id>/', purchase_views.EditPurchaseView.as_view(), name='edit_purchase'),
+    path('delete_purchase/<int:id>/', purchase_views.DeletePurchaseView.as_view(), name='delete_purchase')
 ]

--- a/src/purchase/views.py
+++ b/src/purchase/views.py
@@ -1,7 +1,62 @@
+from django.http import HttpResponseRedirect
+from django.utils.decorators import method_decorator
+from django.urls import reverse_lazy
 from django.views.generic import (
-    ListView, UpdateView, DetailView,
-    DeleteView, CreateView, TemplateView
-)
+    ListView, UpdateView, DetailView, DeleteView, CreateView )
+from .forms import PurchaseCreationForm, EditPurchaseForm
+from .models import Purchase
+from decorators.decorators import group_required
 
-class Purchase(TemplateView):
+decorators = [group_required(['Admin','Manager','General Manager'])]
+@method_decorator(decorators, name="dispatch")
+class PurchaseListView(ListView):
+    queryset = Purchase.objects.all().order_by('id')
+    paginate_by = 10
+    context_object_name = 'purchase_list'
     template_name = 'purchase/purchase.html'
+
+@method_decorator(decorators, name='dispatch')
+class PurchaseCreationView(CreateView):
+    form_class = PurchaseCreationForm
+    template_name = 'purchase/add_purchase.html'
+    success_message = 'Success: Purchase creation succeeded.'
+    success_url = reverse_lazy('setting')
+
+    def post(self, request, *args, **kwargs):
+        data = {
+            'name': request.POST.get('name', None),
+            'description': request.POST.get('description', None),
+            'quantity': request.POST.get('quantity', 0),
+            'cost_price': request.POST.get('cost_price', 0),
+            'current_stock_level': request.POST.get('current_stock_level', 0),
+            'total_stock_level': int(request.POST.get('quantity', 0)) + int(request.POST.get('current_stock_level', 0)),
+            'supplier_tel': request.POST.get('supplier_tel', None),
+            'created_by': request.user.id
+        }
+        if request.method == 'POST':
+            form = self.form_class(data)
+
+            if form.is_valid():
+                form.save()
+
+                return HttpResponseRedirect(self.success_url)
+
+        return super().post(request, *args, **kwargs)
+
+
+@method_decorator(decorators, name='dispatch')
+class EditPurchaseView(UpdateView, DetailView):
+    template_name = 'purchase/edit_purchase.html'
+    pk_url_kwarg = 'id'
+    form_class = EditPurchaseForm
+    queryset = Purchase.objects.all()
+    success_url = reverse_lazy('setting')
+
+
+@method_decorator(decorators, name='dispatch')
+class DeletePurchaseView(DeleteView):
+    template_name = 'purchase/delete_purchase.html'
+    pk_url_kwarg = 'id'
+    queryset = Purchase.objects.all()
+    success_url = reverse_lazy('setting')
+

--- a/src/stocks/admin.py
+++ b/src/stocks/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/src/stocks/templates/stocks/products.html
+++ b/src/stocks/templates/stocks/products.html
@@ -33,7 +33,11 @@
     <!-- End of modal -->
     <!-- content -->
     <div class="text-monospace">
-        {% if product_list.length > 0 %}
+        {% if not product_list %}        
+            <div class="d-flex justify-content-center">
+                <p>No stocks available yet! Please use the New Product button to add some. </p>
+            </div>
+        {% else %}
             <div class="row text-muted border-bottom mb-2">
                 <div class="col-2 pl-5">Name</div>
                 <div class="col-5 px-0">Description</div>
@@ -84,10 +88,6 @@
                         {% endif %}
                     </span>
                 </span>
-            </div>
-        {% else %}
-            <div class="d-flex justify-content-center">
-                <p>No stocks available yet! Please use the New Product button to add some. </p>
             </div>
         {% endif %}
     </div>

--- a/src/stocks/tests/test_forms.py
+++ b/src/stocks/tests/test_forms.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ValidationError
 from accounts.models import User
 from ..forms import ProductCreationForm, EditProductForm
 
-class RoleCreationFormTest(TestCase):
+class ProductCreationFormTest(TestCase):
     def setUp(self):
         self.test = User.objects.create_user("test", "test@info.com", "1234@test")
         self.prod_creater = ProductCreationForm()

--- a/src/stocks/views.py
+++ b/src/stocks/views.py
@@ -1,5 +1,4 @@
 from django.http import HttpResponseRedirect
-from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
 from django.urls import reverse_lazy
 from django.views.generic import (
@@ -15,7 +14,6 @@ class ProductListView(ListView):
     paginate_by = 10
     context_object_name = 'product_list'
     template_name = 'stocks/products.html'
-    
 
 @method_decorator(decorators, name='dispatch')
 class ProductCreationView(CreateView):
@@ -28,9 +26,9 @@ class ProductCreationView(CreateView):
         data = {
             'name': request.POST.get('name', None),
             'description': request.POST.get('description', None),
-            'quantity': request.POST.get('quantity', None),
-            'unit_price': request.POST.get('unit_price', None),
-            'stock_level': request.POST.get('quantity', None), 
+            'quantity': request.POST.get('quantity', 0),
+            'unit_price': request.POST.get('unit_price', 0),
+            'stock_level': request.POST.get('quantity', 0),
             'created_by': request.user.id
         }
         if request.method == 'POST':


### PR DESCRIPTION
#### What does this PR do?
This PR add views for accessing and manipulating the purchase app from the browser.

#### Description of Task to be completed?
- Add views for the purchase app.

#### How should this be manually tested?
- Clone this branch
- In the root directory run `python manage.py runserver`
- Navigate to `http://127.0.0.1:8000/` to login
- Navigate to `http://127.0.0.1:8000/accounts/settings` 
- Select `Purchases` menu on the left to see list of purchases
- Click on the `Add Purchase` button
- Select the `Action` links to edit or delete a purchase

#### Any background context you want to provide?
Currently the purchase app doesn't have a view function. There should be views to handle manipulation of the purchase model data. This should enable access to the data through a graphical interface

#### What are the relevant pivotal tracker stories?
[#168168753](https://www.pivotaltracker.com/story/show/168168753)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/29800415/64193691-f18c8080-ce85-11e9-85c6-8bfe59cdefb0.png)

#### Questions:
N/A