### PR TITLE
#170204022 Make Dashboard Cards Clickable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
             cd src/
             pipenv install --skip-lock
             . $(pipenv --venv)/bin/activate
-            pip install django==2.2.4 django-easy-pdf WeasyPrint psycopg2==2.8.3
+            pip install django==2.2.8 django-easy-pdf WeasyPrint psycopg2==2.8.3
             python manage.py test
   
   upload_coverage:
@@ -62,7 +62,7 @@ jobs:
             cd src/
             pipenv install --skip-lock
             . $(pipenv --venv)/bin/activate
-            pip install django==2.2.4 django-easy-pdf WeasyPrint psycopg2==2.8.3
+            pip install django==2.2.8 django-easy-pdf WeasyPrint psycopg2==2.8.3
             coverage run manage.py test
             coverage xml
             python-codacy-coverage -r coverage.xml

--- a/Pipfile
+++ b/Pipfile
@@ -21,7 +21,7 @@ requests = "==2.22.0"
 sqlparse = "==0.3.0"
 urllib3 = "==1.25.3"
 whitenoise = "==4.1.3"
-Django = "==2.2.4"
+Django = "==2.2.8"
 
 [requires]
 python_version = "3.7"

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -27,7 +27,7 @@ RUN chmod +x start.sh
 RUN pipenv install --skip-lock --system && \
     apk --update --upgrade add gcc musl-dev jpeg-dev zlib-dev \
     libffi-dev cairo-dev pango-dev gdk-pixbuf-dev && \
-    pip install django==2.2.4 django-easy-pdf
+    pip install django==2.2.8 django-easy-pdf
 
 CMD bash -c "source start.sh"
 

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -27,7 +27,7 @@ RUN chmod +x prod_start.sh
 RUN pipenv install --skip-lock --system && \
     apk --update --upgrade add gcc musl-dev jpeg-dev zlib-dev \
     libffi-dev cairo-dev pango-dev gdk-pixbuf-dev && \
-    pip install django==2.2.4 django-easy-pdf
+    pip install django==2.2.8 django-easy-pdf
 
 CMD bash -c "source prod_start.sh"
 

--- a/src/accounts/templates/accounts/home.html
+++ b/src/accounts/templates/accounts/home.html
@@ -13,47 +13,58 @@
             logoText.innerHTML = title;
         });
     </script>
-    <div class="container my-4">
+    <div class="container my-4" style="max-width: 90%;">
         <img id="user_logo" src="/media/{{ company.logo }}" alt="{{ company.name }}">
         <h5 class="text-uppercase font-weight-lighter text-primary ml-3">Summary</h5>
         <div class="row justify-content-center">
-            <div class="card shadow my-4 mx-4" style="width: 20rem;">
-                <div class="card-body text-center">
-                    <h5 class="card-title text-muted">Total Users</h5>
-                    <h4 class="card-text text-primary font-weight-bold">{{ users }}</h4>
+            <a class="navbar-brand" href="{% url 'reports' %}">
+                <div class="card shadow my-4 mx-4" style="width: 20rem;">
+                    <div class="card-body text-center">
+                        <h5 class="card-title text-muted">Total Users</h5>
+                        <h4 class="card-text text-primary font-weight-bold">{{ users }}</h4>
+                    </div>
                 </div>
-            </div>
-            <div class="card shadow my-4 mx-4" style="width: 20rem;">
-                <div class="card-body text-center">
-                    <h5 class="card-title text-muted">Total User Roles</h5>
-                    <h4 class="card-text text-primary font-weight-bold">{{ roles }}</h4>
+            </a>
+            <a class="navbar-brand" href="{% url 'reports' %}">
+                <div class="card shadow my-4 mx-4" style="width: 20rem;">
+                    <div class="card-body text-center">
+                        <h5 class="card-title text-muted">Total User Roles</h5>
+                        <h4 class="card-text text-primary font-weight-bold">{{ roles }}</h4>
+                    </div>
                 </div>
-            </div>
-            <div class="card shadow my-4 mx-4" style="width: 20rem;">
-                <div class="card-body text-center">
-                    <h5 class="card-title text-muted">Total Purchases</h5>
-                    <h4 class="card-text text-primary font-weight-bold">{{ purchases }}</h4>
+            </a>
+            <a class="navbar-brand" href="{% url 'reports' %}">
+                <div class="card shadow my-4 mx-4" style="width: 20rem;">
+                    <div class="card-body text-center">
+                        <h5 class="card-title text-muted">Total Purchases</h5>
+                        <h4 class="card-text text-primary font-weight-bold">{{ purchases }}</h4>
+                    </div>
                 </div>
-            </div>
-            <div class="card shadow my-4 mx-4" style="width: 20rem;">
-                <div class="card-body text-center">
-                    <h5 class="card-title text-muted">Total Stock Types</h5>
-                    <h4 class="card-text text-primary font-weight-bold">{{ stocks }}</h4>
+            </a>
+            <a class="navbar-brand" href="{% url 'reports' %}">
+                <div class="card shadow my-4 mx-4" style="width: 20rem;">
+                    <div class="card-body text-center">
+                        <h5 class="card-title text-muted">Total Stock Types</h5>
+                        <h4 class="card-text text-primary font-weight-bold">{{ stocks }}</h4>
+                    </div>
                 </div>
-            </div>
-            <div class="card shadow my-4 mx-4" style="width: 20rem;">
-                <div class="card-body text-center">
-                    <h5 class="card-title text-muted">Total Sales Transactions</h5>
-                    <h4 class="card-text text-primary font-weight-bold">{{ sales }}</h4>
+            </a>
+            <a class="navbar-brand" href="{% url 'reports' %}">
+                <div class="card shadow my-4 mx-4" style="width: 20rem;">
+                    <div class="card-body text-center">
+                        <h5 class="card-title text-muted">Total Sales Transactions</h5>
+                        <h4 class="card-text text-primary font-weight-bold">{{ sales }}</h4>
+                    </div>
                 </div>
-            </div>
-            <div class="card shadow my-4 mx-4" style="width: 20rem;">
-                <div class="card-body text-center">
-                    <h5 class="card-title text-muted">Total Expenses Category</h5>
-                    <h4 class="card-text text-primary font-weight-bold">{{ category }}</h4>
+            </a>
+            <a class="navbar-brand" href="{% url 'reports' %}">
+                <div class="card shadow my-4 mx-4" style="width: 20rem;">
+                    <div class="card-body text-center">
+                        <h5 class="card-title text-muted">Total Expenses Category</h5>
+                        <h4 class="card-text text-primary font-weight-bold">{{ category }}</h4>
+                    </div>
                 </div>
-            </div>
+            </a>
         </div>
     </div>
-
 {% endblock %}


### PR DESCRIPTION
#### What does this PR do?
This PR update the dashboard to make the summary cards clickable

#### Description of Task to be completed?
- Make the dashboard summary clickable

#### How should this be manually tested?
- Clone this branch
- In the root directory run `python manage.py runserver`
- Navigate to `http://127.0.0.1:8000/` to login
- You should see summaries cards on the Dashboard
- Click the cards to take you to the `Reports` for details

#### Any background context you want to provide?
Currently the dashboard summary cards are not clickable. This should be made clickable so that when a user clicks on it, then they should be directed to the report page for the clicked items.

#### What are the relevant pivotal tracker stories?
[#170204022](https://www.pivotaltracker.com/story/show/170204022)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/29800415/68956039-49295f80-07d8-11ea-8ef9-d12a32517960.png)

#### Questions:
N/A